### PR TITLE
Download archives

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -19,12 +19,12 @@ readonly g_filename_template=__BINARY_NAME__-v__VERSION__-__PLATFORM__
 # available : __GITHUB_COORDINATES__/__VERSION__/__VERSION_SHORT__/__FILENAME__
 #
 # shellcheck disable=SC2034
-readonly g_download_url_template=https://github.com/__GITHUB_COORDINATES__/releases/download/v__VERSION__/__FILENAME__
+readonly g_download_url_template=https://github.com/__GITHUB_COORDINATES__/releases/download/v__VERSION__/__FILENAME__.tar.gz
 #
 # available : __ARCHIVE_DIR__/__BINARY_NAME__/__VERSION__/__VERSION_SHORT__/__PLATFORM__
 #
-readonly g_binary_path_in_archive_template=__ARCHIVE_DIR__/__BINARY_NAME__-v__VERSION__-__PLATFORM__
-readonly g_downloaded_file_is_not_an_archive=true
+readonly g_binary_path_in_archive_template=__ARCHIVE_DIR__/__BINARY_NAME__
+readonly g_downloaded_file_is_not_an_archive=false
 readonly g_platform_pattern=uname_l_dash_amd64 # one of uname_c_x86_64|uname_l_dash_amd64|uname_l_underscore_amd64|custom
 
 # Borrowed to someone, but I don't remember who it was, sorry :(


### PR DESCRIPTION
This is required for 0.13+ and should work with 0.10+ but <=0.9 did not provide an archive.