### PR TITLE
Add installation support for multiple platforms

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ readonly g_download_url_template=https://github.com/__GITHUB_COORDINATES__/relea
 #
 readonly g_binary_path_in_archive_template=__ARCHIVE_DIR__/__BINARY_NAME__
 readonly g_downloaded_file_is_not_an_archive=false
-readonly g_platform_pattern=uname_l_dash_amd64 # one of uname_c_x86_64|uname_l_dash_amd64|uname_l_underscore_amd64|custom
+readonly g_platform_pattern=custom # one of uname_c_x86_64|uname_l_dash_amd64|uname_l_underscore_amd64|custom
 
 # Borrowed to someone, but I don't remember who it was, sorry :(
 # Print message $2 with log-level $1 to STDERR, colorized if terminal
@@ -188,7 +188,17 @@ get_platform() {
 }
 
 get_platform_custom() {
-  echo "NOT USED"
+  local machine_hardware_name
+  machine_hardware_name=${ASDF_OVERWRITE_ARCH:-"$(uname -m)"}
+
+  case "${machine_hardware_name}" in
+    'x86_64') local cpu_type="amd64" ;;
+    'aarch64') local cpu_type="arm64" ;;
+    'armv7l') local cpu_type="arm" ;;
+    *) local cpu_type="${machine_hardware_name}" ;;
+  esac
+
+  echo "$(uname | tr '[:upper:]' '[:lower:]')-${cpu_type}"
 }
 
 get_platform_uname_c_x86_64() {


### PR DESCRIPTION
This MR update code to add support for the installation of terraform-docs for the following platforms/architectures

- amd64
- arm64
- arm