### PR TITLE
Fix sentinal check

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -105,7 +105,7 @@ install_tool() {
   local bin_install_path="$install_path/bin"
   local full_path_to_binary="$bin_install_path/${binary_name}"
   local full_path_to_alt_binary
-  if [[ -n "$binary_alt_name" || "$binary_alt_name" == "$NO_BINARY_ALTNAME" ]]; then
+  if [[ -n "$binary_alt_name" && "$binary_alt_name" != "$NO_BINARY_ALTNAME" ]]; then
     full_path_to_alt_binary="$bin_install_path/${binary_alt_name}"
   fi
   local download_url
@@ -143,7 +143,7 @@ install_tool() {
 
   log INFO "Cleaning previous binaries if any"
   rm -f "$full_path_to_binary" 2>/dev/null || true
-  if [[ -n "$binary_alt_name" ]]; then
+  if [[ -n "$binary_alt_name" && "$binary_alt_name" != "$NO_BINARY_ALTNAME" ]]; then
     rm -f "$full_path_to_alt_binary" 2>/dev/null || true
   fi
   if [[ "$downloaded_file_is_not_an_archive" != "true" ]]; then
@@ -160,7 +160,7 @@ install_tool() {
   fi
   cp "${bpath_in_archive}" "${full_path_to_binary}"
   chmod +x "${full_path_to_binary}"
-  if [[ -n "$binary_alt_name" ]]; then
+  if [[ -n "$binary_alt_name" && "$binary_alt_name" != "$NO_BINARY_ALTNAME" ]]; then
     cp "${full_path_to_binary}" "${full_path_to_alt_binary}"
     chmod +x "${full_path_to_alt_binary}"
   fi


### PR DESCRIPTION
As this code is, it checks if $binary_alt_name is non null (which it always is) and then skips the check to see if it's the sentinel value. This results in this:

```bash
> cd .asdf/installs/terraform-docs/0.20.0/bin && ls
@@UNDEFINED@@*	terraform-docs*
```

This PR fixes the checks so no `@@UNDEFINED@@` binary gets created.